### PR TITLE
set 'bestaudio' param to choose the best audio only option

### DIFF
--- a/src/main/yt/yt.ts
+++ b/src/main/yt/yt.ts
@@ -142,7 +142,7 @@ async function play(identifier: string) {
             "https://youtube.com/watch?v=" + identifier,
             "-x",
             "-f",
-            "best"
+            "bestaudio"
         ];
 
         const BROWSER_FOR_COOKIES = config.getConfigValue("ytCookieSource");


### PR DESCRIPTION
The previous param 'best' might cause errors in some cases. Currently 'bestaudio' param is used which will only select the best audio only format. Else 'bestaudio*' can also be used if we don't care that best audio format might also contain video.



