### PR TITLE
nix: init package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1745391562,
+        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+
+  outputs = {
+    nixpkgs,
+    self,
+    ...
+  }: let
+    inherit (nixpkgs) legacyPackages lib;
+
+    # Compose for multiple systems. Please do not replace this with nix-systems as it is
+    # not guaranteed to build on platforms we haven't tested on.
+    systems = ["x86_64-linux"];
+    forEachSystem = lib.genAttrs systems;
+    pkgsForEach = legacyPackages;
+  in {
+    # Provide a formatter for `nix fmt`
+    formatter = forEachSystem (system: nixpkgs.legacyPackages.${system}.alejandra);
+
+    packages = forEachSystem (system: let
+      pkgs = pkgsForEach.${system};
+    in {
+      default = self.packages.${system}.vermillion;
+      vermillion = pkgs.callPackage ./nix/package.nix {inherit self;};
+    });
+
+    devShells = forEachSystem (system: let
+      pkgs = pkgsForEach.${system};
+    in {
+      default = self.devShells.${system}.vermillion;
+      vermillion = pkgs.mkShellNoCC {
+        name = "vermillion-dev";
+        packages = with pkgs; [
+          # Eslint_d
+          nodejs-slim
+          pnpm
+        ];
+      };
+    });
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,6 +7,7 @@
   makeWrapper,
   electron,
   xdg-utils,
+  yt-dlp,
   ...
 }: let
   fs = lib.fileset;
@@ -62,7 +63,7 @@ in
       runHook preBuild
 
       cp -r ${electron.dist} electron-dist
-      chmod -R u+w electron-dist
+      chmod -R u+w electron-dist # for possible Darwin support in the future
 
       pnpm run build
       pnpm exec electron-builder \
@@ -79,8 +80,14 @@ in
     # *never* catch me unpacking an appimage again.
     # - raf
     installPhase = let
-      # For Electron & file pickers
-      binPath = lib.makeBinPath [xdg-utils];
+      binPath = lib.makeBinPath [
+        # For Electron & file pickers
+        xdg-utils
+
+        # For YT-Music integration
+        # https://github.com/vaxerski/Vermilion/blob/main/docs/YTM.md
+        yt-dlp
+      ];
     in ''
       runHook preInstall
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,106 @@
+{
+  self,
+  lib,
+  stdenvNoCC,
+  nodejs,
+  pnpm_10,
+  makeWrapper,
+  electron,
+  xdg-utils,
+  ...
+}: let
+  fs = lib.fileset;
+in
+  stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "vermillion";
+    version =
+      if (self ? rev)
+      then (builtins.substring 0 7 self.rev)
+      else "dirty";
+
+    src = let
+      sp = ../.;
+    in
+      fs.toSource {
+        root = sp;
+
+        # Filter everything outside of what's specified here. Configuration files
+        # are good to include, but linter/formatter configs are not necessary.
+        fileset = fs.intersection (fs.fromSource (lib.sources.cleanSource sp)) (
+          fs.unions [
+            ../build
+            ../resources
+            ../src
+            ../package.json
+            ../pnpm-lock.yaml
+            ../svelte.config.mjs
+            ../electron-builder.yml
+            ../electron.vite.config.ts
+            ../tsconfig.json
+            ../tsconfig.node.json
+            ../tsconfig.web.json
+          ]
+        );
+      };
+
+    pnpmDeps = pnpm_10.fetchDeps {
+      inherit (finalAttrs) pname src;
+      hash = "sha256-al2WTriEbOfpObi69gQ2ykwanQ5t6EvrryyUVbdSb44=";
+    };
+
+    nativeBuildInputs = [
+      makeWrapper
+      pnpm_10.configHook
+      nodejs
+    ];
+
+    # npm install will error when electron tries to download its binary
+    # we don't need it anyways since we wrap the program with our nixpkgs electron
+    env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+    buildPhase = ''
+      runHook preBuild
+
+      cp -r ${electron.dist} electron-dist
+      chmod -R u+w electron-dist
+
+      pnpm run build
+      pnpm exec electron-builder \
+        --dir \
+        -c.electronDist=electron-dist \
+        -c.electronVersion="${electron.version}" \
+
+      runHook postBuild
+    '';
+
+    # This is, by far, the most stupid way of packaging an application. Not my fault though
+    # because Electron is stupid. The method employed here is easier (and cheaper) than
+    # building the appimage, then making Nix aware of it, AND then unpacking it. You will
+    # *never* catch me unpacking an appimage again.
+    # - raf
+    installPhase = let
+      # For Electron & file pickers
+      binPath = lib.makeBinPath [xdg-utils];
+    in ''
+      runHook preInstall
+
+      mkdir -p $out/share/vermillion
+      cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/vermillion
+
+      makeWrapper '${lib.getExe electron}' "$out/bin/vermillion" \
+        --inherit-argv0 \
+        --add-flags $out/share/vermillion/resources/app.asar \
+        --suffix PATH : "${binPath}" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Clean, minimal and simple music player for MPD and Tidal";
+      homepage = "https://github.com/vaxerski/vermilion";
+      license = lib.licenses.bsd3;
+      maintainers = [lib.maintainers.NotAShelf];
+      platforms = lib.platforms.linux;
+    };
+  })


### PR DESCRIPTION
Basic Nix packaging for Vermillion. Tested as best as I can, but I have not yet
tried hooking into MPD or Tidal (which is not available to me.)

Should work as intended unless there are weird runtime dependencies needed. One
caveat is that the dependency has will need to be updated manually when pnpm
lock changes. I'll take a look at automating the hash change in the future, but
for now lets get packaging done.
